### PR TITLE
Add GolangCI linting and refactor package names

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,47 @@
+run:
+  tests: true
+  allow-parallel-runners: false
+linters-settings:
+  errcheck:
+    check-type-assertions: true
+  govet:
+    enable-all: true
+  goimports:
+    local-prefixes: github.com/kaudit/auth
+  gocyclo:
+    min-complexity: 10
+  misspell:
+    locale: US
+linters:
+  enable:
+    - errcheck
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - typecheck
+    - unused
+    - gocyclo
+    - gofmt
+    - goimports
+    - misspell
+    - unparam
+    - revive
+    - gochecknoinits
+    - gochecknoglobals
+  disable:
+    - depguard
+    - dupl
+  presets:
+    - bugs
+    - unused
+  fast: false
+issues:
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - gocyclo
+        - errcheck
+        - dupl
+        - gosec
+        - gochecknoglobals

--- a/k8s_auth_data_loader/k8s_auth_data_loader.go
+++ b/k8s_auth_data_loader/k8s_auth_data_loader.go
@@ -1,4 +1,4 @@
-package k8s_auth_data_loader
+package k8sauthdataloader
 
 import (
 	"fmt"

--- a/k8s_auth_data_loader/k8s_auth_data_loader_test.go
+++ b/k8s_auth_data_loader/k8s_auth_data_loader_test.go
@@ -1,4 +1,4 @@
-package k8s_auth_data_loader
+package k8sauthdataloader
 
 import (
 	"os"

--- a/kube_config/kube_config.go
+++ b/kube_config/kube_config.go
@@ -1,4 +1,4 @@
-package kube_config
+package kubeconfig
 
 import (
 	"fmt"

--- a/kube_config/kube_config_test.go
+++ b/kube_config/kube_config_test.go
@@ -1,4 +1,4 @@
-package kube_config
+package kubeconfig
 
 import (
 	"errors"
@@ -10,7 +10,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 
-	"github.com/kaudit/auth/mocks/K8sAuthLoader"
+	mocksauth "github.com/kaudit/auth/mocks/K8sAuthLoader"
 )
 
 func TestNewKubeConfigAuthenticator(t *testing.T) {
@@ -21,7 +21,7 @@ func TestNewKubeConfigAuthenticator(t *testing.T) {
 	authenticator, err := NewKubeConfigAuthenticator(mockLoader)
 
 	// Assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, authenticator)
 }
 
@@ -56,7 +56,7 @@ users:
 		client, err := authenticator.NativeAPI()
 
 		// Assert
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.NotNil(t, client)
 		assert.Implements(t, (*kubernetes.Interface)(nil), client)
 	})
@@ -73,7 +73,7 @@ users:
 		client, err := authenticator.NativeAPI()
 
 		// Assert
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Contains(t, err.Error(), "authLoader.Load failed")
 		assert.Nil(t, client)
 	})
@@ -109,7 +109,7 @@ users:
 		client, err := authenticator.NativeAPI()
 
 		// Assert
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Contains(t, err.Error(), "clientCfg.ClientConfig failed")
 		assert.Nil(t, client)
 	})
@@ -128,7 +128,7 @@ users:
 		client, err := authenticator.NativeAPI()
 
 		// Assert
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Contains(t, err.Error(), "getRestConfig failed")
 		assert.Nil(t, client)
 	})
@@ -165,7 +165,7 @@ users:
 		client, err := authenticator.DynamicAPI()
 
 		// Assert
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.NotNil(t, client)
 		assert.Implements(t, (*dynamic.Interface)(nil), client)
 	})
@@ -182,7 +182,7 @@ users:
 		client, err := authenticator.DynamicAPI()
 
 		// Assert
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Contains(t, err.Error(), "authLoader.Load failed")
 		assert.Nil(t, client)
 	})
@@ -218,7 +218,7 @@ users:
 		client, err := authenticator.DynamicAPI()
 
 		// Assert
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Contains(t, err.Error(), "clientCfg.ClientConfig failed")
 		assert.Nil(t, client)
 	})
@@ -237,7 +237,7 @@ users:
 		client, err := authenticator.DynamicAPI()
 
 		// Assert
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Contains(t, err.Error(), "getRestConfig failed")
 		assert.Nil(t, client)
 	})


### PR DESCRIPTION
### Description

- Add a `.golangci.yaml` configuration file to improve linting and maintain code quality.
- Refactor package names by converting underscores to camel case and updating related imports.
- Replace `assert` with `require` in tests for stricter and more robust assertions. 

### Checklist

- [x] Documentation has been updated as necessary.
- [x] Tests have been added or updated to cover the changes.
- [x] Changes conform to the project's coding standards.